### PR TITLE
Fix report invocation bug

### DIFF
--- a/lazyrecon.sh
+++ b/lazyrecon.sh
@@ -471,7 +471,9 @@ outputDirectory=${subreport[1]}
 domain=${subreport[2]}
 foldername=${subreport[3]}
 subd=${subreport[4]}
-report $outputDirectory $domain $subdomain $foldername $subd; exit 1;
+# generate single host report when invoked with -r options
+report
+exit 0
 fi
   clear
   logo


### PR DESCRIPTION
## Summary
- fix usage of undefined variable when generating a single host report

## Testing
- `bash -n lazyrecon.sh`
- `command -v shellcheck >/dev/null && shellcheck lazyrecon.sh`

------
https://chatgpt.com/codex/tasks/task_e_6868a328099083319d631997345bb098