### PR TITLE
Add strict mode to run script

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 if [ $# -lt 1 ]; then
     echo "Usage: $0 <domain>" >&2


### PR DESCRIPTION
## Summary
- enable strict mode in run.sh

## Testing
- `./tests/run_no_args.sh`

------
https://chatgpt.com/codex/tasks/task_e_6869bb8793d08331a0903b6c584a995d