### PR TITLE
Guard ulimit in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ RUN set -x \
     && apt-get clean autoclean \
 	&& apt-get autoremove -y \
 	&& rm -rf /var/lib/{apt,dpkg,cache,log}/ \
-    && ulimit -n 2048 \
+    && ( ulimit -n 2048 || true ) \
     && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 RUN set -x \
     && addgroup --gid 1000 lazyrecon_user \


### PR DESCRIPTION
## Summary
- prevent failure if `ulimit` command is not allowed during Docker build

## Testing
- `tests/run_no_args.sh`

------
https://chatgpt.com/codex/tasks/task_e_686c12314b4c8331ac1932cf35d4387d