### PR TITLE
Add dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,25 @@
+# Ignore version control and CI configs
+.git
+.github
+
+# Ignore temporary results
+lazyrecon_results/
+
+# Ignore local development dirs
+.vscode/
+
+# Ignore tests
+tests/
+
+# Ignore Windows helper scripts and large media files
+run.bat
+recon.gif
+report.gif
+
+# Ignore OS generated files
+.DS_Store
+__pycache__/
+*.pyc
+
+# Ignore all GIFs
+*.gif


### PR DESCRIPTION
## Summary
- add a `.dockerignore` so local results, git files, and large assets aren't sent to Docker
- ignore additional OS files, caches, and gifs

## Testing
- `./tests/run_no_args.sh`
- `docker build .` *(fails: cannot connect to Docker daemon)*


------
https://chatgpt.com/codex/tasks/task_e_6869bb84fff083318bc10089b870722c